### PR TITLE
Add datatype handling

### DIFF
--- a/bark/bark.py
+++ b/bark/bark.py
@@ -27,7 +27,7 @@ Library versions:
  bark: %s
 """ % (version)
 
-_Units = collections.namedtuple('Units', ['TIME_UNITS'])
+_Units = collections.namedtuple('_Units', ['TIME_UNITS'])
 UNITS = _Units(TIME_UNITS=('s', 'samples'))
 
 class DataTypes:

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -148,7 +148,8 @@ class Data():
     def datatype_name(self):
         """Returns the name of the dataset's datatype, or None if unspecified."""
         return DataTypes._fromcode(self.attrs.get('datatype', None))
-   
+
+
 class SampledData(Data):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -29,6 +29,59 @@ Library versions:
 class BarkMetaError(Exception):
     """Raised in case of inconsistency between metadata and Bark objects."""
 
+class DataTypes:
+    """
+    Available ARF data types, by name and integer code.
+    
+    Copied, with some modifications, from Dan Meliza's ARF repo.
+    """
+
+    UNDEFINED = 0
+    ACOUSTIC = 1
+    EXTRAC_HP, EXTRAC_LF, EXTRAC_EEG = range(2, 5)
+    INTRAC_CC, INTRAC_VC = range(5, 7)
+    EVENT, SPIKET, BEHAVET = range(1000, 1003)
+    INTERVAL, STIMI, COMPONENTL = range(2000, 2003)
+
+    @classmethod
+    def _doc(cls):
+        out = str(cls.__doc__)
+        for code,name in sorted(cls._todict().items()):
+            out += '\n{%s}:{%d}'.format(name, code)
+        return out
+
+    @classmethod
+    def is_timeseries(cls, code):
+        """Indicates whether the code corresponds to time series data."""
+        if cls._fromint() is None:
+            raise BarkMetaError('bad datatype code: {}'.format(code))
+        else:
+            if code < cls.EVENT:
+                return True
+            else:
+                return False
+
+    def is_pointproc(cls, code):
+        """Indicates whether the code corresponds to point process data."""
+        return (not cls.is_timeseries(code))
+
+    @classmethod
+    def _todict(cls):
+        """Generate a dictionary keyed by datatype code."""
+        return dict((getattr(cls, attr), attr)
+                     for attr in dir(cls)
+                     if not attr.startswith('_'))
+
+    @classmethod
+    def _fromstring(cls, name):
+        """Returns datatype code given the name, or None if undefined."""
+        return getattr(cls, name.upper(), None)
+
+    @classmethod
+    def _fromcode(cls, code):
+        """Returns datatype name given the code, or None if undefined."""
+        return cls._todict().get(code, None)
+
 # hierarchical classes
 class Root():
     def __init__(self, path, entries=None, attrs=None):

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -182,7 +182,6 @@ def write_sampled(datfile, data, sampling_rate, units, **params):
     mdata = np.memmap(datfile, dtype=params["dtype"], mode="w+", shape=shape)
     mdata[:] = data[:]
     params["filetype"] = "rawbinary"
-    _enforce_units(params)
     write_metadata(datfile + ".meta",
                    sampling_rate=sampling_rate,
                    units=units,
@@ -222,7 +221,6 @@ def write_events(eventsfile, data, **params):
     assert "units" in params and params["units"] in UNITS.TIME_UNITS
     data.to_csv(eventsfile, index=False)
     params["filetype"] = "csv"
-    _enforce_units(params)
     write_metadata(eventsfile + ".meta", **params)
     return read_events(eventsfile)
 
@@ -241,7 +239,6 @@ def read_dataset(fname):
         dset = read_events(fname)
     else:
         dset = read_sampled(fname)
-    _enforce_units(params)
     return dset
 
 
@@ -281,17 +278,6 @@ def write_metadata(filename, **params):
         yaml_file.write(header)
         yaml_file.write(yaml.safe_dump(params, default_flow_style=False))
 
-
-def _enforce_units(params):
-    """
-    Enforces strict adherence to the BARK spec for the 'units' attribute.
-
-    Modifies the given dict in place.
-    """
-    if 'units' in params:
-        if params['units'] == 'seconds':
-            params['units'] = 's'
-    return
 
 def create_root(name, parents=False, **attrs):
     """creates a new BARK top-level directory"""

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -29,6 +29,17 @@ Library versions:
 class BarkMetaError(Exception):
     """Raised in case of inconsistency between metadata and Bark objects."""
 
+class Units:
+    """
+    Units which Bark recognizes and treats as special.
+    
+    Note that Bark will accept any value for units, including None.
+    
+    For more on how Bark treats these units, refer to the spec.
+    """
+    
+    TIME_UNITS = ('s', 'samples')
+
 class DataTypes:
     """
     Available ARF data types, by name and integer code.
@@ -212,7 +223,7 @@ def read_sampled(datfile, mode="r"):
 
 
 def write_events(eventsfile, data, **params):
-    assert "units" in params and params["units"] in ["s" or "samples"]
+    assert "units" in params and params["units"] in Units.TIME_UNITS
     data.to_csv(eventsfile, index=False)
     params["filetype"] = "csv"
     write_metadata(eventsfile + ".meta", **params)
@@ -229,7 +240,7 @@ def read_events(eventsfile):
 def read_dataset(fname):
     "determines if file is sampled or event data and reads accordingly"
     params = read_metadata(fname + ".meta")
-    if "units" in params and params["units"] in ("s", "samples"):
+    if "units" in params and params["units"] in Units.TIME_UNITS:
         return read_events(fname)
     else:
         return read_sampled(fname)
@@ -307,7 +318,7 @@ def _enforce_datatype(params):
             raise BarkMetaError('bad datatype code: {}'.format(code))
     else:
         try:
-            if params['units'] in ('s', 'samples'):
+            if params['units'] in Units.TIME_UNITS:
                 params['datatype_name'] = 'EVENT'
                 params['datatype'] = DataTypes._fromname('EVENT')
             else:
@@ -444,7 +455,7 @@ def is_sampled(dset):
     if 'datatype' in dset.attrs:
         return DataTypes.is_timeseries(dset.attrs['datatype'])
     elif 'units' in dset.attrs:
-        return (dset.attrs['units'] not in ('s', 'samples'))
+        return (dset.attrs['units'] not in Units.TIME_UNITS)
     else:
         # this only occurs if the dset has been created but not written yet
         msg = "dataset has neither 'units' nor 'datatype' metadata"

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -287,10 +287,8 @@ def _enforce_units(params):
     Modifies the given dict in place.
     """
     if 'units' in params:
-        if params['units'] is not None:
-            params['units'] = params['units'].lower()
-            if params['units'] == 'seconds':
-                params['units'] = 's'
+        if params['units'] == 'seconds':
+            params['units'] = 's'
     return
 
 def _enforce_datatype(params):

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -26,9 +26,6 @@ Library versions:
  bark: %s
 """ % (version)
 
-class BarkMetaError(Exception):
-    """Raised in case of inconsistency between metadata and Bark objects."""
-
 class Units:
     """
     Units which Bark recognizes and treats as special.
@@ -65,7 +62,7 @@ class DataTypes:
     def is_timeseries(cls, code):
         """Indicates whether the code corresponds to time series data."""
         if cls._fromint() is None:
-            raise BarkMetaError('bad datatype code: {}'.format(code))
+            raise KeyError('bad datatype code: {}'.format(code))
         else:
             if code < cls.EVENT:
                 return True
@@ -307,7 +304,7 @@ def _enforce_datatype(params):
     """
     Checks params['datatype'] against canonical list.
 
-    Throws BarkMetaError if params['datatype'] is not on the list.
+    Throws KeyError if params['datatype'] is not on the list.
 
     If there is no 'datatype' attribute, infers time series / point process
     identity from 'units' and assigns either 0/UNDEFINED or 1000/EVENT,
@@ -317,7 +314,7 @@ def _enforce_datatype(params):
     """
     if 'datatype' in params:
         if DataTypes._fromcode(params['datatype']) is None:
-            raise BarkMetaError('bad datatype code: {}'.format(code))
+            raise KeyError('bad datatype code: {}'.format(code))
     elif 'units' in params and params['units'] in Units.TIME_UNITS:
         params['datatype_name'] = 'EVENT'
         params['datatype'] = DataTypes._fromstring('EVENT')
@@ -456,7 +453,7 @@ def is_sampled(dset):
     else:
         # this only occurs if the dset has been created but not written yet
         msg = "dataset has neither 'units' nor 'datatype' metadata"
-        raise BarkMetaError(msg)
+        raise KeyError(msg)
 
 
 def is_events(dset):

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -440,11 +440,17 @@ def get_uuid(obj):
 
 
 def is_sampled(dset):
-    """Returns True if dset is a sampled time series (units are not time)"""
-    return isinstance(dset, np.memmap)
+    """Returns True if dset is a sampled time series."""
+    if 'datatype' in dset.attrs:
+        return DataTypes.is_timeseries(dset.attrs['datatype'])
+    elif 'units' in dset.attrs:
+        return (dset.attrs['units'] not in ('s', 'samples'))
+    else:
+        # this only occurs if the dset has been created but not written yet
+        msg = "dataset has neither 'units' nor 'datatype' metadata"
+        raise BarkMetaError(msg)
 
 
 def is_events(dset):
-    """Returns True if dset is a marked point process (a complex dtype with 'start' field)"""
-    import pandas as pd
-    return isinstance(dset.data, pd.DataFrame) and 'start' in dset.data.columns
+    """Returns True if dset is a point process."""
+    return (not is_sampled(dset))

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -318,17 +318,12 @@ def _enforce_datatype(params):
     if 'datatype' in params:
         if DataTypes._fromcode(params['datatype']) is None:
             raise BarkMetaError('bad datatype code: {}'.format(code))
+    elif 'units' in params and params['units'] in Units.TIME_UNITS:
+        params['datatype_name'] = 'EVENT'
+        params['datatype'] = DataTypes._fromstring('EVENT')
     else:
-        try:
-            if params['units'] in Units.TIME_UNITS:
-                params['datatype_name'] = 'EVENT'
-                params['datatype'] = DataTypes._fromstring('EVENT')
-            else:
-                params['datatype_name'] = 'UNDEFINED'
-                params['datatype'] = DataTypes._fromstring('UNDEFINED')
-        except KeyError:
-            msg = "dataset has neither 'units' nor 'datatype' metadata"
-            raise BarkMetaError(msg)
+        params['datatype_name'] = 'UNDEFINED'
+        params['datatype'] = DataTypes._fromstring('UNDEFINED')
     return
 
 def create_root(name, parents=False, **attrs):

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -61,7 +61,7 @@ class DataTypes:
                 return True
             else:
                 return False
-
+    @classmethod
     def is_pointproc(cls, code):
         """Indicates whether the code corresponds to point process data."""
         return (not cls.is_timeseries(code))

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -26,7 +26,6 @@ Library versions:
  bark: %s
 """ % (version)
 
-
 # hierarchical classes
 class Root():
     def __init__(self, path, entries=None, attrs=None):
@@ -174,7 +173,7 @@ def read_events(eventsfile):
 def read_dataset(fname):
     "determines if file is sampled or event data and reads accordingly"
     params = read_metadata(fname + ".meta")
-    if "units" in params and params["units"] in ("s", "seconds"):
+    if "units" in params and params["units"] in ("s", "samples"):
         return read_events(fname)
     else:
         return read_sampled(fname)
@@ -206,7 +205,6 @@ to create a .meta file interactively, type:
 $ dat-meta {dat}
         """.format(dat=metafile))
         sys.exit(0)
-
 
 def write_metadata(filename, **params):
     for k, v in params.items():

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -273,7 +273,7 @@ $ dat-meta {dat}
         sys.exit(0)
     
     _enforce_units(params)
-    _enforce_datatypes(params)
+    _enforce_datatype(params)
     return params
 
 def write_metadata(filename, **params):
@@ -281,7 +281,7 @@ def write_metadata(filename, **params):
         if isinstance(v, (np.ndarray, np.generic)):
             params[k] = v.tolist()
     _enforce_units(params)
-    _enforce_datatypes(params)
+    _enforce_datatype(params)
     with codecs.open(filename, 'w', encoding='utf-8') as yaml_file:
         header = """# metadata using YAML syntax\n---\n"""
         yaml_file.write(header)
@@ -320,10 +320,10 @@ def _enforce_datatype(params):
         try:
             if params['units'] in Units.TIME_UNITS:
                 params['datatype_name'] = 'EVENT'
-                params['datatype'] = DataTypes._fromname('EVENT')
+                params['datatype'] = DataTypes._fromstring('EVENT')
             else:
                 params['datatype_name'] = 'UNDEFINED'
-                params['datatype'] = DataTypes._fromname('UNDEFINED')
+                params['datatype'] = DataTypes._fromstring('UNDEFINED')
         except KeyError:
             msg = "dataset has neither 'units' nor 'datatype' metadata"
             raise BarkMetaError(msg)

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -54,7 +54,7 @@ class DataTypes:
     @classmethod
     def is_timeseries(cls, code):
         """Indicates whether the code corresponds to time series data."""
-        if cls._fromcode() is None:
+        if cls._fromcode(code) is None:
             raise KeyError('bad datatype code: {}'.format(code))
         else:
             if code < cls.EVENT:
@@ -307,7 +307,7 @@ def _enforce_datatype(params):
     """
     if 'datatype' in params:
         if DataTypes._fromcode(params['datatype']) is None:
-            raise KeyError('bad datatype code: {}'.format(code))
+            raise KeyError('bad datatype code: {}'.format(params['datatype']))
     elif 'units' in params and params['units'] in UNITS.TIME_UNITS:
         params['datatype_name'] = 'EVENT'
         params['datatype'] = DataTypes._fromstring('EVENT')

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -54,7 +54,7 @@ class DataTypes:
     @classmethod
     def is_timeseries(cls, code):
         """Indicates whether the code corresponds to time series data."""
-        if cls._fromint() is None:
+        if cls._fromcode() is None:
             raise KeyError('bad datatype code: {}'.format(code))
         else:
             if code < cls.EVENT:

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -26,6 +26,9 @@ Library versions:
  bark: %s
 """ % (version)
 
+class BarkMetaError(Exception):
+    """Raised in case of inconsistency between metadata and Bark objects."""
+
 # hierarchical classes
 class Root():
     def __init__(self, path, entries=None, attrs=None):

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -186,7 +186,6 @@ def read_metadata(metafile):
     try:
         with codecs.open(metafile, 'r', encoding='utf-8') as fp:
             params = yaml.safe_load(fp)
-        return params
     except IOError as err:
         fname = os.path.splitext(metafile)[0]
         if fname == "meta":
@@ -208,16 +207,33 @@ to create a .meta file interactively, type:
 $ dat-meta {dat}
         """.format(dat=metafile))
         sys.exit(0)
+    
+    _enforce_units(params)
+    return params
 
 def write_metadata(filename, **params):
     for k, v in params.items():
         if isinstance(v, (np.ndarray, np.generic)):
             params[k] = v.tolist()
+    _enforce_units(params)
     with codecs.open(filename, 'w', encoding='utf-8') as yaml_file:
         header = """# metadata using YAML syntax\n---\n"""
         yaml_file.write(header)
         yaml_file.write(yaml.safe_dump(params, default_flow_style=False))
 
+
+def _enforce_units(params):
+    """
+    Enforces strict adherence to the BARK spec for the 'units' attribute.
+
+    Modifies the given dict in place.
+    """
+    if 'units' in params:
+        if params['units'] is not None:
+            params['units'] = params['units'].lower()
+            if params['units'] == 'seconds':
+                params['units'] = 's'
+    return
 
 def create_root(name, parents=False, **attrs):
     """creates a new BARK top-level directory"""

--- a/bark/bark.py
+++ b/bark/bark.py
@@ -149,23 +149,6 @@ class Data():
         """Returns the name of the dataset's datatype, or None if unspecified."""
         return DataTypes._fromcode(self.attrs.get('datatype', None))
    
-    @property
-    def is_events(self):
-        """Returns True if dataset is a point process."""
-        if self.attrs.get('units', None) in UNITS.TIME_UNITS:
-            return True
-        elif 'sampling_rate' in self.attrs:
-            return False
-        else:
-            # indeterminate - something went wrong during dataset creation
-            raise KeyError('dataset without units of time must have sampling rate')
-    
-    @property
-    def is_sampled(self):
-        """Returns True if dataset is a sampled time series."""
-        return (not self.is_events)
-
-
 class SampledData(Data):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/bark/tools/barksplit.py
+++ b/bark/tools/barksplit.py
@@ -161,7 +161,7 @@ def gen_split_files(entry, sampled_ds, event_ds, splits, split_on, point_mode):
         new_ds_list.append(new_ds)
     return new_ds_list
 
-def parse_args(raw_args):
+def _parse_args(raw_args):
     desc = ('Splits a sampled-data record according to the split times in a ' +
             'label file. Works on both single entries and recursively over ' +
             'an entire BARK root.')
@@ -224,7 +224,7 @@ def split_dataset(path,
                                           point_mode)
 
 def _main():
-    args = parse_args(sys.argv[1:])
+    args = _parse_args(sys.argv[1:])
     split_dataset(args.path,
                   args.sampled_data,
                   args.label_file,

--- a/tests/test_bark.py
+++ b/tests/test_bark.py
@@ -59,12 +59,12 @@ def test_read_dataset(tmpdir):
     
     path = os.path.join(tmpdir.strpath, 'test_samp')
     data = np.zeros((10,3),dtype="int16")
-    params = {'sampling_rate': 30000, 'units' = 'mV', 'unit_scale': 0.025}
+    params = {'sampling_rate': 30000, 'units': 'mV', 'unit_scale': 0.025}
     samp_written = bark.write_sampled(path, data=data, **params)
     samp_read = bark.read_dataset(path)
     assert samp_read.attrs['units'] == params['units']
     assert samp_read.attrs['datatype'] == 0
-    assert samp_read.attrs['datatype_name'] == 'UNDEFINED
+    assert samp_read.attrs['datatype_name'] == 'UNDEFINED'
 
 def test_create_root(tmpdir):
     path = os.path.join(tmpdir.strpath, "mybark")
@@ -102,33 +102,35 @@ def test_datatypes():
     assert bark.DataTypes._fromstring('UNDEFINED') == 0
     assert bark.DataTypes._fromstring('EVENT') == 1000
     assert bark.DataTypes._fromcode(1) == 'ACOUSTIC'
-    assert bark.DataTypes._fromcode(2002) == 'COMPONENTL"
+    assert bark.DataTypes._fromcode(2002) == 'COMPONENTL'
 
 def test__enforce_units():
+    from bark.bark import _enforce_units
     params = {'units': 'seconds'}
-    bark._enforce_units(params)
+    _enforce_units(params)
     assert params['units'] == 's'
     params['units'] = 'samples'
-    bark._enforce_units(params)
+    _enforce_units(params)
     assert params['units'] == 'samples'
 
-def test__enforce_datatypes():
+def test__enforce_datatype():
+    from bark.bark import _enforce_datatype
     params = {'datatype': 2}
-    bark._enforce_datatypes(params) # should do nothing
+    _enforce_datatype(params) # should do nothing
 
     params['datatype'] = -1
     with pytest.raises(KeyError):
-        bark._enforce_datatypes(params)
+        _enforce_datatype(params)
 
     params = {'units': 's'}
-    bark._enforce_datatypes(params)
+    _enforce_datatype(params)
     assert params['datatype'] == 1000
     assert params['datatype_name'] == 'EVENT'
     
     params = {'units': 'mV'}
-    bark._enforce_datatypes(params)
+    _enforce_datatype(params)
     assert params['datatype'] == 0
-    assert params['datatype'] == 'UNDEFINED'
+    assert params['datatype_name'] == 'UNDEFINED'
 
 def test_dset_type_checkers(tmpdir):
     data = np.zeros((10,3),dtype="int16")

--- a/tests/test_bark.py
+++ b/tests/test_bark.py
@@ -73,3 +73,15 @@ def test_entry_sort(tmpdir):
     mylist = sorted([entry2, entry1])
     assert mylist[0] == entry1
     assert mylist[1] == entry2
+
+def test_datatypes():
+    assert bark.DataTypes.is_timeseries(0)
+    assert bark.DataTypes.is_timeseries(1)
+    assert (not bark.DataTypes.is_timeseries(1000))
+    assert (not bark.DataTypes.is_timeseries(2002))
+    assert bark.DataTypes.is_pointproc(1000)
+    assert bark.DataTypes._fromstring('UNDEFINED') == 0
+    assert bark.DataTypes._fromstring('EVENT') == 1000
+    assert bark.DataTypes._fromcode(1) == 'ACOUSTIC'
+    assert bark.DataTypes._fromcode(2002) == 'COMPONENTL"
+    

--- a/tests/test_bark.py
+++ b/tests/test_bark.py
@@ -47,6 +47,25 @@ def test_write_events(tmpdir):
     assert 'name' in events.data.columns
     assert np.allclose([0, 1, 2, 3], events.data.start)
 
+def test_read_dataset(tmpdir):
+    path = os.path.join(tmpdir.strpath, 'test_events')
+    data = pd.DataFrame({'start': [0,1,2,3], 'stop': [1,2,3,4],
+                         'name': ['a', 'b', 'c', 'd']})
+    event_written = bark.write_events(path, data, units='s')
+    event_read = bark.read_dataset(path)
+    assert event_read.attrs['units'] == 's'
+    assert event_read.attrs['datatype'] == 1000
+    assert event_read.attrs['datatype_name'] == 'EVENT'
+    
+    path = os.path.join(tmpdir.strpath, 'test_samp')
+    data = np.zeros((10,3),dtype="int16")
+    params = {'sampling_rate': 30000, 'units' = 'mV', 'unit_scale': 0.025}
+    samp_written = bark.write_sampled(path, data=data, **params)
+    samp_read = bark.read_dataset(path)
+    assert samp_read.attrs['units'] == params['units']
+    assert samp_read.attrs['datatype'] == 0
+    assert samp_read.attrs['datatype_name'] == 'UNDEFINED
+
 def test_create_root(tmpdir):
     path = os.path.join(tmpdir.strpath, "mybark")
     root = bark.create_root(path, experimenter="kjbrown",

--- a/tests/test_bark.py
+++ b/tests/test_bark.py
@@ -99,13 +99,3 @@ def test_datatypes():
     assert bark.DataTypes._fromstring('EVENT') == 1000
     assert bark.DataTypes._fromcode(1) == 'ACOUSTIC'
     assert bark.DataTypes._fromcode(2002) == 'COMPONENTL'
-
-def test__enforce_units():
-    from bark.bark import _enforce_units
-    params = {'units': 'seconds'}
-    _enforce_units(params)
-    assert params['units'] == 's'
-    params['units'] = 'samples'
-    _enforce_units(params)
-    assert params['units'] == 'samples'
-

--- a/tests/test_bark.py
+++ b/tests/test_bark.py
@@ -129,3 +129,18 @@ def test__enforce_datatypes():
     bark._enforce_datatypes(params)
     assert params['datatype'] == 0
     assert params['datatype'] == 'UNDEFINED'
+
+def test_dset_type_checkers(tmpdir):
+    data = np.zeros((10,3),dtype="int16")
+    params = dict(sampling_rate=30000, units="mV", unit_scale=0.025,
+            extra="barley")
+    samp = bark.write_sampled(os.path.join(tmpdir.strpath, "test_sampled"), data=data, **params)
+    assert bark.is_sampled(samp)
+    assert (not bark.is_events(samp))
+
+    path = os.path.join(tmpdir.strpath, "test_events")
+    data = pd.DataFrame({'start': [0,1,2,3], 'stop': [1,2,3,4],
+            'name': ['a','b','c','d']})
+    events = bark.write_events(path, data, units='s')
+    assert (not bark.is_sampled(events))
+    assert bark.is_events(events)

--- a/tests/test_bark.py
+++ b/tests/test_bark.py
@@ -109,17 +109,3 @@ def test__enforce_units():
     _enforce_units(params)
     assert params['units'] == 'samples'
 
-def test_dset_type_checkers(tmpdir):
-    data = np.zeros((10,3),dtype="int16")
-    params = dict(sampling_rate=30000, units="mV", unit_scale=0.025,
-            extra="barley")
-    samp = bark.write_sampled(os.path.join(tmpdir.strpath, "test_sampled"), data=data, **params)
-    assert samp.is_sampled
-    assert (not samp.is_events)
-
-    path = os.path.join(tmpdir.strpath, "test_events")
-    data = pd.DataFrame({'start': [0,1,2,3], 'stop': [1,2,3,4],
-            'name': ['a','b','c','d']})
-    events = bark.write_events(path, data, units='s')
-    assert (not events.is_sampled)
-    assert events.is_events

--- a/tests/test_bark.py
+++ b/tests/test_bark.py
@@ -84,4 +84,29 @@ def test_datatypes():
     assert bark.DataTypes._fromstring('EVENT') == 1000
     assert bark.DataTypes._fromcode(1) == 'ACOUSTIC'
     assert bark.DataTypes._fromcode(2002) == 'COMPONENTL"
+
+def test__enforce_units():
+    params = {'units': 'seconds'}
+    bark._enforce_units(params)
+    assert params['units'] == 's'
+    params['units'] = 'samples'
+    bark._enforce_units(params)
+    assert params['units'] == 'samples'
+
+def test__enforce_datatypes():
+    params = {'datatype': 2}
+    bark._enforce_datatypes(params) # should do nothing
+
+    params['datatype'] = -1
+    with pytest.raises(KeyError):
+        bark._enforce_datatypes(params)
+
+    params = {'units': 's'}
+    bark._enforce_datatypes(params)
+    assert params['datatype'] == 1000
+    assert params['datatype_name'] == 'EVENT'
     
+    params = {'units': 'mV'}
+    bark._enforce_datatypes(params)
+    assert params['datatype'] == 0
+    assert params['datatype'] == 'UNDEFINED'


### PR DESCRIPTION
Datatype code taken almost entirely from melizalab/arf.

Also:
* Make specially-treated time units a module-level constant
* Check units and datatypes upon every dataset read/write
* Refactor dataset type checkers to examine units and datatypes
* Add tests for new features